### PR TITLE
Centered calendar approch1

### DIFF
--- a/app/styles/_calendar.scss
+++ b/app/styles/_calendar.scss
@@ -1,5 +1,6 @@
 @import url(http://fonts.googleapis.com/css?family=Inconsolata:400,700);
 #full-clndr {
+  display:block;
   margin: 0 auto;
   max-width: 90%;
   width: 100%;


### PR DESCRIPTION
Es el display: inline-block del clearfix el que hace eso, puede también
ponerle al elemento padre text-align:center y sirve pero también le
centra el h2 si es lo que quiere es más fácil también